### PR TITLE
Backports for 4.1 build

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -343,4 +343,10 @@ static inline bool seq_has_overflowed(struct seq_file *m)
 
 #endif /* < KERNEL_VERSION(3, 19, 0) */
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
+
+#define dev_get_iflink(_net_dev) ((_net_dev)->iflink)
+
+#endif /* < KERNEL_VERSION(4, 1, 0) */
+
 #endif /* _NET_BATMAN_ADV_COMPAT_H_ */

--- a/hard-interface.c
+++ b/hard-interface.c
@@ -83,7 +83,7 @@ static bool batadv_is_on_batman_iface(const struct net_device *net_dev)
 		return true;
 
 	/* no more parents..stop recursion */
-	if (net_dev->iflink == net_dev->ifindex)
+	if (net_dev->iflink == 0 || net_dev->iflink == net_dev->ifindex)
 		return false;
 
 	/* recurse over the parent device */

--- a/hard-interface.c
+++ b/hard-interface.c
@@ -83,11 +83,12 @@ static bool batadv_is_on_batman_iface(const struct net_device *net_dev)
 		return true;
 
 	/* no more parents..stop recursion */
-	if (net_dev->iflink == 0 || net_dev->iflink == net_dev->ifindex)
+	if (dev_get_iflink(net_dev) == 0 ||
+	    dev_get_iflink(net_dev) == net_dev->ifindex)
 		return false;
 
 	/* recurse over the parent device */
-	parent_dev = __dev_get_by_index(&init_net, net_dev->iflink);
+	parent_dev = __dev_get_by_index(&init_net, dev_get_iflink(net_dev));
 	/* if we got a NULL parent_dev there is something broken.. */
 	if (WARN(!parent_dev, "Cannot find parent device"))
 		return false;

--- a/hard-interface.c
+++ b/hard-interface.c
@@ -87,15 +87,13 @@ static bool batadv_is_on_batman_iface(const struct net_device *net_dev)
 		return false;
 
 	/* recurse over the parent device */
-	parent_dev = dev_get_by_index(&init_net, net_dev->iflink);
+	parent_dev = __dev_get_by_index(&init_net, net_dev->iflink);
 	/* if we got a NULL parent_dev there is something broken.. */
 	if (WARN(!parent_dev, "Cannot find parent device"))
 		return false;
 
 	ret = batadv_is_on_batman_iface(parent_dev);
 
-	if (parent_dev)
-		dev_put(parent_dev);
 	return ret;
 }
 


### PR DESCRIPTION
Here are some backports from the upstream batman-adv with which building batman-adv-legacy on a 4.1 kernel should be possible again.