### PR TITLE
add DKMS support for batman-adv-legacy

### DIFF
--- a/README.external
+++ b/README.external
@@ -25,6 +25,25 @@ if you want to install this module:
 
 # sudo make install
 
+DKMS
+----
+To simplify rebuilding of the  module after a kernel upgrade, the
+DKMS (Dynamic Kernel Module Support) system can be used.
+
+For Debian/Ubuntu:
+# apt-get install linux-headers dkms
+# git clone https://github.com/freifunk-gluon/batman-adv-legacy /usr/src/batman-adv-legacy-2013.4.0
+# dkms add -m batman-adv-legacy -v 2013.4.0
+# dkms build -m batman-adv-legacy -v 2013.4.0 && dkms install -m batman-adv-legacy -v 2013.4.0 --force
+
+The  last line must  be run  whenever a  kernel upgrade  has been
+installed. It  can also be added to  something like /etc/rc.local
+so that it is executed on every reboot. It doesn't do anything if
+the module is already built and installed for the current kernel.
+
+To remove module from DKMS:
+# dkms remove -m batman-adv-legacy -v 2013.4.0 --all
+
 CONFIGURATION
 -------------
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME=batman-adv-legacy
+PACKAGE_VERSION=2013.4.0
+BUILT_MODULE_NAME[0]="batman-adv"
+MAKE[0]="KERNELPATH=${kernel_source_dir} make"
+CLEAN="KERNELPATH=${kernel_source_dir} make clean"
+DEST_MODULE_LOCATION[0]=/updates/net/batman-adv
+AUTOINSTALL=yes
+UDEV_TRIGGER=no


### PR DESCRIPTION
This could be useful for installing the legacy batman-adv module on a normal Linux system (like the Gatemon Raspberry Pis we use at Freifunk Bremen). With DKMS the module can be more easily rebuilt after a kernel upgrade.