### PR TITLE
batman-adv: add DAT cache netlink support

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -218,6 +218,13 @@ static inline void batadv_eth_hw_addr_random(struct net_device *dev)
 	} while (0)
 #endif /* ifndef net_ratelimited_function */
 
+static inline int nla_put_be32(struct sk_buff *skb, int attrtype, __be32 value)
+{
+	__be32 tmp = value;
+
+	return nla_put(skb, attrtype, sizeof(__be32), &tmp);
+}
+
 #endif /* < KERNEL_VERSION(3, 5, 0) */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)
@@ -485,6 +492,14 @@ static inline bool seq_has_overflowed(struct seq_file *m)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
 
 #define dev_get_iflink(_net_dev) ((_net_dev)->iflink)
+
+static inline int nla_put_in_addr(struct sk_buff *skb, int attrtype,
+				  __be32 addr)
+{
+	__be32 tmp = addr;
+
+	return nla_put_be32(skb, attrtype, tmp);
+}
 
 #endif /* < KERNEL_VERSION(4, 1, 0) */
 

--- a/distributed-arp-table.c
+++ b/distributed-arp-table.c
@@ -19,17 +19,24 @@
 
 #include <linux/if_ether.h>
 #include <linux/if_arp.h>
+#include <linux/netlink.h>
 #include <net/arp.h>
+#include <net/genetlink.h>
+#include <net/netlink.h>
+#include <net/sock.h>
 
 #include "main.h"
 #include "hash.h"
 #include "distributed-arp-table.h"
 #include "hard-interface.h"
+#include "netlink.h"
 #include "originator.h"
 #include "send.h"
+#include "soft-interface.h"
 #include "types.h"
 #include "translation-table.h"
 #include "unicast.h"
+#include "uapi/linux/batman_adv.h"
 
 static void batadv_dat_purge(struct work_struct *work);
 
@@ -718,6 +725,151 @@ out:
 	if (primary_if)
 		batadv_hardif_free_ref(primary_if);
 	return 0;
+}
+
+ /**
+ * batadv_dat_cache_dump_entry() - dump one entry of the DAT cache table to a
+ *  netlink socket
+ * @msg: buffer for the message
+ * @portid: netlink port
+ * @seq: Sequence number of netlink message
+ * @dat_entry: entry to dump
+ *
+ * Return: 0 or error code.
+ */
+static int
+batadv_dat_cache_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
+			    struct batadv_dat_entry *dat_entry)
+{
+	int msecs;
+	void *hdr;
+
+	hdr = genlmsg_put(msg, portid, seq, &batadv_netlink_family,
+			  NLM_F_MULTI, BATADV_CMD_GET_DAT_CACHE);
+	if (!hdr)
+		return -ENOBUFS;
+
+	msecs = jiffies_to_msecs(jiffies - dat_entry->last_update);
+
+	if (nla_put_in_addr(msg, BATADV_ATTR_DAT_CACHE_IP4ADDRESS,
+			    dat_entry->ip) ||
+	    nla_put(msg, BATADV_ATTR_DAT_CACHE_HWADDRESS, ETH_ALEN,
+		    dat_entry->mac_addr) ||
+	    nla_put_u16(msg, BATADV_ATTR_DAT_CACHE_VID, 0) ||
+	    nla_put_u32(msg, BATADV_ATTR_LAST_SEEN_MSECS, msecs)) {
+		genlmsg_cancel(msg, hdr);
+		return -EMSGSIZE;
+	}
+
+	genlmsg_end(msg, hdr);
+	return 0;
+}
+
+/**
+ * batadv_dat_cache_dump_bucket() - dump one bucket of the DAT cache table to
+ *  a netlink socket
+ * @msg: buffer for the message
+ * @portid: netlink port
+ * @seq: Sequence number of netlink message
+ * @head: bucket to dump
+ * @idx_skip: How many entries to skip
+ *
+ * Return: 0 or error code.
+ */
+static int
+batadv_dat_cache_dump_bucket(struct sk_buff *msg, u32 portid, u32 seq,
+			     struct hlist_head *head, int *idx_skip)
+{
+	struct batadv_dat_entry *dat_entry;
+	int idx = 0;
+
+	rcu_read_lock();
+	hlist_for_each_entry_rcu(dat_entry, head, hash_entry) {
+		if (idx < *idx_skip)
+			goto skip;
+
+		if (batadv_dat_cache_dump_entry(msg, portid, seq,
+						dat_entry)) {
+			rcu_read_unlock();
+			*idx_skip = idx;
+
+			return -EMSGSIZE;
+		}
+
+skip:
+		idx++;
+	}
+	rcu_read_unlock();
+
+	return 0;
+}
+
+/**
+ * batadv_dat_cache_dump() - dump DAT cache table to a netlink socket
+ * @msg: buffer for the message
+ * @cb: callback structure containing arguments
+ *
+ * Return: message length.
+ */
+int batadv_dat_cache_dump(struct sk_buff *msg, struct netlink_callback *cb)
+{
+	struct batadv_hard_iface *primary_if = NULL;
+	int portid = NETLINK_CB(cb->skb).portid;
+	struct net *net = sock_net(cb->skb->sk);
+	struct net_device *soft_iface;
+	struct batadv_hashtable *hash;
+	struct batadv_priv *bat_priv;
+	int bucket = cb->args[0];
+	struct hlist_head *head;
+	int idx = cb->args[1];
+	int ifindex;
+	int ret = 0;
+
+	ifindex = batadv_netlink_get_ifindex(cb->nlh,
+					     BATADV_ATTR_MESH_IFINDEX);
+	if (!ifindex)
+		return -EINVAL;
+
+	soft_iface = dev_get_by_index(net, ifindex);
+	if (!soft_iface || !batadv_softif_is_valid(soft_iface)) {
+		ret = -ENODEV;
+		goto out;
+	}
+
+	bat_priv = netdev_priv(soft_iface);
+	hash = bat_priv->dat.hash;
+
+	primary_if = batadv_primary_if_get_selected(bat_priv);
+	if (!primary_if || primary_if->if_status != BATADV_IF_ACTIVE) {
+		ret = -ENOENT;
+		goto out;
+	}
+
+	while (bucket < hash->size) {
+		head = &hash->table[bucket];
+
+		if (batadv_dat_cache_dump_bucket(msg, portid,
+						 cb->nlh->nlmsg_seq, head,
+						 &idx))
+			break;
+
+		bucket++;
+		idx = 0;
+	}
+
+	cb->args[0] = bucket;
+	cb->args[1] = idx;
+
+	ret = msg->len;
+
+out:
+	if (primary_if)
+		batadv_hardif_free_ref(primary_if);
+
+	if (soft_iface)
+		dev_put(soft_iface);
+
+	return ret;
 }
 
 /**

--- a/distributed-arp-table.h
+++ b/distributed-arp-table.h
@@ -27,6 +27,8 @@
 
 #include <linux/if_arp.h>
 
+struct netlink_callback;
+
 #define BATADV_DAT_ADDR_MAX ((batadv_dat_addr_t)~(batadv_dat_addr_t)0)
 
 bool batadv_dat_snoop_outgoing_arp_request(struct batadv_priv *bat_priv,
@@ -73,6 +75,7 @@ batadv_dat_init_own_addr(struct batadv_priv *bat_priv,
 int batadv_dat_init(struct batadv_priv *bat_priv);
 void batadv_dat_free(struct batadv_priv *bat_priv);
 int batadv_dat_cache_seq_print_text(struct seq_file *seq, void *offset);
+int batadv_dat_cache_dump(struct sk_buff *msg, struct netlink_callback *cb);
 
 /**
  * batadv_dat_inc_counter - increment the correct DAT packet counter
@@ -155,6 +158,12 @@ static inline int batadv_dat_init(struct batadv_priv *bat_priv)
 
 static inline void batadv_dat_free(struct batadv_priv *bat_priv)
 {
+}
+
+static inline int
+batadv_dat_cache_dump(struct sk_buff *msg, struct netlink_callback *cb)
+{
+	return -EOPNOTSUPP;
 }
 
 static inline void batadv_dat_inc_counter(struct batadv_priv *bat_priv,

--- a/netlink.c
+++ b/netlink.c
@@ -40,6 +40,7 @@
 
 #include "bat_algo.h"
 #include "bridge_loop_avoidance.h"
+#include "distributed-arp-table.h"
 #include "gateway_client.h"
 #include "hard-interface.h"
 #include "originator.h"
@@ -83,6 +84,9 @@ static struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
 	[BATADV_ATTR_BLA_VID]		= { .type = NLA_U16 },
 	[BATADV_ATTR_BLA_BACKBONE]	= { .len = ETH_ALEN },
 	[BATADV_ATTR_BLA_CRC]		= { .type = NLA_U16 },
+	[BATADV_ATTR_DAT_CACHE_IP4ADDRESS]	= { .type = NLA_U32 },
+	[BATADV_ATTR_DAT_CACHE_HWADDRESS]	= { .len = ETH_ALEN },
+	[BATADV_ATTR_DAT_CACHE_VID]		= { .type = NLA_U16 },
 };
 
 /**
@@ -370,6 +374,12 @@ static __genl_const struct genl_ops batadv_netlink_ops[] = {
 		.flags = GENL_ADMIN_PERM,
 		.policy = batadv_netlink_policy,
 		.dumpit = batadv_bla_backbone_dump,
+	},
+	{
+		.cmd = BATADV_CMD_GET_DAT_CACHE,
+		.flags = GENL_ADMIN_PERM,
+		.policy = batadv_netlink_policy,
+		.dumpit = batadv_dat_cache_dump,
 	},
 
 };

--- a/uapi/linux/batman_adv.h
+++ b/uapi/linux/batman_adv.h
@@ -96,6 +96,9 @@ enum batadv_tt_client_flags {
  * @BATADV_ATTR_BLA_VID: BLA VLAN ID
  * @BATADV_ATTR_BLA_BACKBONE: BLA gateway originator MAC address
  * @BATADV_ATTR_BLA_CRC: BLA CRC
+ * @BATADV_ATTR_DAT_CACHE_IP4ADDRESS: Client IPv4 address
+ * @BATADV_ATTR_DAT_CACHE_HWADDRESS: Client MAC address
+ * @BATADV_ATTR_DAT_CACHE_VID: VLAN ID
  * @__BATADV_ATTR_AFTER_LAST: internal use
  * @NUM_BATADV_ATTR: total number of batadv_nl_attrs available
  * @BATADV_ATTR_MAX: highest attribute number currently defined
@@ -136,6 +139,9 @@ enum batadv_nl_attrs {
 	BATADV_ATTR_BLA_VID,
 	BATADV_ATTR_BLA_BACKBONE,
 	BATADV_ATTR_BLA_CRC,
+	BATADV_ATTR_DAT_CACHE_IP4ADDRESS,
+	BATADV_ATTR_DAT_CACHE_HWADDRESS,
+	BATADV_ATTR_DAT_CACHE_VID,
 	/* add attributes above here, update the policy in netlink.c */
 	__BATADV_ATTR_AFTER_LAST,
 	NUM_BATADV_ATTR = __BATADV_ATTR_AFTER_LAST,
@@ -158,6 +164,7 @@ enum batadv_nl_attrs {
  * @BATADV_CMD_GET_GATEWAYS: Query list of gateways
  * @BATADV_CMD_GET_BLA_CLAIM: Query list of bridge loop avoidance claims
  * @BATADV_CMD_GET_BLA_BACKBONE: Query list of bridge loop avoidance backbones
+ * @BATADV_CMD_GET_DAT_CACHE: Query list of DAT cache entries
  * @__BATADV_CMD_AFTER_LAST: internal use
  * @BATADV_CMD_MAX: highest used command number
  */
@@ -175,6 +182,7 @@ enum batadv_nl_commands {
 	BATADV_CMD_GET_GATEWAYS,
 	BATADV_CMD_GET_BLA_CLAIM,
 	BATADV_CMD_GET_BLA_BACKBONE,
+	BATADV_CMD_GET_DAT_CACHE,
 	/* add new commands above here */
 	__BATADV_CMD_AFTER_LAST,
 	BATADV_CMD_MAX = __BATADV_CMD_AFTER_LAST - 1


### PR DESCRIPTION
Dump the list of DAT cache entries via the netlink socket.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>
[linus.luessing@c0d3.blue: backport to batman-adv-legacy]
Signed-off-by: Sven Eckelmann \<sven@narfation.org\>