### PR TITLE
soft-interface: fix compilation on Kernel 5.4

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -709,4 +709,10 @@ batadv_genl_unregister_family(struct batadv_genl_family *family)
 
 #endif /* < KERNEL_VERSION(5, 2, 0) */
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
+
+#define nf_reset_ct nf_reset
+
+#endif /* < KERNEL_VERSION(5, 4, 0) */
+
 #endif /* _NET_BATMAN_ADV_COMPAT_H_ */

--- a/soft-interface.c
+++ b/soft-interface.c
@@ -316,7 +316,7 @@ void batadv_interface_rx(struct net_device *soft_iface,
 	/* clean the netfilter state now that the batman-adv header has been
 	 * removed
 	 */
-	nf_reset(skb);
+	nf_reset_ct(skb);
 
 	ethhdr = eth_hdr(skb);
 


### PR DESCRIPTION
Linux commit 895b5c9f206eb ("netfilter: drop bridge nf reset from nf_reset ")
renamed nf_reset to nf_reset_ct. Use the new function on >= 5.4 kernels.

fixes #17 