### PR TITLE
batman-adv: netfilter: drop bridge nf reset from nf_reset

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -709,4 +709,13 @@ batadv_genl_unregister_family(struct batadv_genl_family *family)
 
 #endif /* < KERNEL_VERSION(5, 2, 0) */
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
+
+#define nf_reset_ct nf_reset
+
+#endif /* < KERNEL_VERSION(5, 4, 0) */
+
+#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_SKBUFF_H_ */
+
+
 #endif /* _NET_BATMAN_ADV_COMPAT_H_ */

--- a/soft-interface.c
+++ b/soft-interface.c
@@ -316,7 +316,7 @@ void batadv_interface_rx(struct net_device *soft_iface,
 	/* clean the netfilter state now that the batman-adv header has been
 	 * removed
 	 */
-	nf_reset(skb);
+	nf_reset_ct(skb);
 
 	ethhdr = eth_hdr(skb);
 


### PR DESCRIPTION
commit 174e23810cd31
("sk_buff: drop all skb extensions on free and skb scrubbing") made napi
recycle always drop skb extensions.  The additional skb_ext_del() that is
performed via nf_reset on napi skb recycle is not needed anymore.

Most nf_reset() calls in the stack are there so queued skb won't block
'rmmod nf_conntrack' indefinitely.

This removes the skb_ext_del from nf_reset, and renames it to a more
fitting nf_reset_ct().

In a few selected places, add a call to skb_ext_reset to make sure that
no active extensions remain.

I am submitting this for "net", because we're still early in the release
cycle.  The patch applies to net-next too, but I think the rename causes
needless divergence between those trees.

Suggested-by: Eric Dumazet <edumazet@google.com>
Signed-off-by: Florian Westphal <fw@strlen.de>
Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
[sven@narfation.org: add compat code]
Signed-off-by: Sven Eckelmann <sven@narfation.org>
[Christian Bricart: rebase to batadv-legacy]